### PR TITLE
Add BTC quantitative analysis Colab notebook

### DIFF
--- a/notebooks/BTC_Quant_Colab.ipynb
+++ b/notebooks/BTC_Quant_Colab.ipynb
@@ -1,0 +1,122 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install ccxt pandas ta pytz matplotlib ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ccxt\n",
+    "import pandas as pd\n",
+    "import ta\n",
+    "import pytz\n",
+    "import matplotlib.pyplot as plt\n",
+    "from datetime import datetime\n",
+    "import time\n",
+    "\n",
+    "exchange = ccxt.kraken()\n",
+    "market = 'BTC/USD' if 'BTC/USD' in exchange.symbols else 'XBT/USD'\n",
+    "\n",
+    "def fetch_ohlcv(timeframe='1h', limit=500):\n",
+    "    ohlcv = exchange.fetch_ohlcv(market, timeframe=timeframe, limit=limit)\n",
+    "    df = pd.DataFrame(ohlcv, columns=['timestamp','open','high','low','close','volume'])\n",
+    "    df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms', utc=True)\n",
+    "    df['timestamp'] = df['timestamp'].dt.tz_convert('America/Denver')\n",
+    "    return df.set_index('timestamp')\n",
+    "\n",
+    "def add_indicators(df):\n",
+    "    df['SMA50'] = df['close'].rolling(50).mean()\n",
+    "    df['SMA200'] = df['close'].rolling(200).mean()\n",
+    "    df['RSI'] = ta.momentum.rsi(df['close'], window=14)\n",
+    "    macd = ta.trend.macd(df['close'], window_slow=26, window_fast=12)\n",
+    "    macd_signal = ta.trend.macd_signal(df['close'], window_slow=26, window_fast=12, window_sign=9)\n",
+    "    df['MACD'] = macd\n",
+    "    df['MACD_signal'] = macd_signal\n",
+    "    return df\n",
+    "\n",
+    "def generate_signal(df):\n",
+    "    return 'Bullish' if df['SMA50'].iloc[-1] > df['SMA200'].iloc[-1] else 'Bearish'\n",
+    "\n",
+    "def run_once(timeframe='1h'):\n",
+    "    df = fetch_ohlcv(timeframe)\n",
+    "    df = add_indicators(df)\n",
+    "    signal = generate_signal(df)\n",
+    "    now = datetime.now(pytz.timezone('America/Denver')).strftime('%Y-%m-%d %H:%M:%S')\n",
+    "    print(f\"{now} - {signal}\")\n",
+    "    return df\n",
+    "\n",
+    "def live_watch(timeframe='1h', loops=60, sleep_s=60):\n",
+    "    for _ in range(loops):\n",
+    "        run_once(timeframe)\n",
+    "        time.sleep(sleep_s)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n",
+    "\n",
+    "tf_dropdown = widgets.Dropdown(options=['5m','15m','1h'], value='1h', description='Timeframe:')\n",
+    "run_btn = widgets.Button(description='Run snapshot')\n",
+    "live_btn = widgets.Button(description='Start live')\n",
+    "\n",
+    "def on_run(btn):\n",
+    "    df = run_once(tf_dropdown.value)\n",
+    "    display(df.tail())\n",
+    "\n",
+    "def on_live(btn):\n",
+    "    live_watch(tf_dropdown.value, loops=60, sleep_s=60)\n",
+    "\n",
+    "run_btn.on_click(on_run)\n",
+    "live_btn.on_click(on_live)\n",
+    "\n",
+    "display(tf_dropdown, run_btn, live_btn)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = run_once('1h')\n",
+    "fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 8), sharex=True)\n",
+    "ax1.plot(df.index, df['close'], label='Price')\n",
+    "ax1.plot(df.index, df['SMA50'], label='SMA50')\n",
+    "ax1.plot(df.index, df['SMA200'], label='SMA200')\n",
+    "ax1.legend()\n",
+    "ax1.set_title('BTC Price with SMA50/200')\n",
+    "ax2.plot(df.index, df['RSI'], label='RSI')\n",
+    "ax2.axhline(30, color='red', linestyle='--')\n",
+    "ax2.axhline(70, color='red', linestyle='--')\n",
+    "ax2.set_title('RSI')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add Colab notebook with ccxt-based BTC data fetch from Kraken
- compute SMA50, SMA200, RSI, MACD with signal generation
- include ipywidgets UI for snapshot and live watching with plotting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae0e7ff9648327bc466fee778219c0