### PR TITLE
Pro dashboard UI (Streamlit): live Signal HUD, KPI cards, Plotly charts, CSV download

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,108 @@
+import time
+from datetime import datetime
+
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+import streamlit as st
+
+from quant_core import TZ, add_indicators, classify_signal, latest_snapshot
+
+st.set_page_config(page_title="BTC Quant Dashboard", layout="wide")
+
+# ---------- Sidebar Controls ----------
+st.sidebar.title("Controls")
+timeframe = st.sidebar.selectbox("Timeframe", ["5m", "15m", "1h", "4h", "1d"], index=2)
+refresh_s = st.sidebar.slider("Refresh (seconds)", 5, 120, 20, step=5)
+show_ema = st.sidebar.checkbox("Show EMA(50/200)", value=True)
+show_sma = st.sidebar.checkbox("Show SMA(50/200)", value=True)
+st.sidebar.caption("Data source: Kraken via ccxt. Times in America/Denver.")
+
+# ---------- Header ----------
+st.markdown(
+    """
+    <style>
+    .sig-badge {
+        display:inline-block; padding:10px 16px; border-radius:12px;
+        font-weight:700; font-size:22px; margin-right:12px;
+    }
+    .bull { background:#e7f7ed; color:#137333; border:1px solid #b7e3c7; }
+    .bear { background:#fde8e7; color:#a50e0e; border:1px solid #f6c1bf; }
+    .neutral { background:#eef2f7; color:#334155; border:1px solid #cbd5e1; }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+# ---------- Data fetch ----------
+df, sig, now = latest_snapshot(timeframe)
+last = df.iloc[-1]
+close_val = float(last["close"])
+rsi_val = float(last["RSI"])
+macd_val = float(last["MACD"])
+macds_val = float(last["MACDSignal"])
+
+# ---------- Top row KPIs ----------
+col1, col2, col3, col4 = st.columns([1.4, 1, 1, 1])
+badge_class = "bull" if sig == "Bullish" else ("bear" if sig == "Bearish" else "neutral")
+with col1:
+    st.markdown(f'<span class="sig-badge {badge_class}">Signal: {sig}</span>', unsafe_allow_html=True)
+    st.caption(f"Updated: {now}")
+with col2:
+    st.metric("Close (USD)", f"{close_val:,.2f}")
+with col3:
+    st.metric("RSI (14)", f"{rsi_val:,.1f}")
+with col4:
+    trend_txt = "Above" if macd_val > macds_val else "Below"
+    st.metric("MACD vs Signal", trend_txt, delta=f"{(macd_val - macds_val):.2f}")
+
+st.divider()
+
+# ---------- Chart ----------
+fig = make_subplots(
+    rows=2,
+    cols=1,
+    shared_xaxes=True,
+    row_heights=[0.7, 0.3],
+    vertical_spacing=0.05,
+)
+
+# Price
+fig.add_trace(go.Scatter(x=df.index, y=df["close"], name="Price", mode="lines"), row=1, col=1)
+
+if show_sma:
+    fig.add_trace(go.Scatter(x=df.index, y=df["SMA50"], name="SMA50", mode="lines"), row=1, col=1)
+    fig.add_trace(go.Scatter(x=df.index, y=df["SMA200"], name="SMA200", mode="lines"), row=1, col=1)
+
+if show_ema:
+    fig.add_trace(go.Scatter(x=df.index, y=df["EMA50"], name="EMA50", mode="lines"), row=1, col=1)
+    fig.add_trace(go.Scatter(x=df.index, y=df["EMA200"], name="EMA200", mode="lines"), row=1, col=1)
+
+# RSI
+fig.add_trace(go.Scatter(x=df.index, y=df["RSI"], name="RSI", mode="lines"), row=2, col=1)
+fig.add_hline(y=70, line_dash="dot", row=2, col=1)
+fig.add_hline(y=30, line_dash="dot", row=2, col=1)
+
+fig.update_layout(
+    height=600,
+    margin=dict(l=40, r=20, t=40, b=40),
+    legend=dict(orientation="h", y=1.02, x=0),
+)
+fig.update_xaxes(showgrid=False)
+fig.update_yaxes(showgrid=True, gridwidth=1, gridcolor="rgba(148,163,184,.25)")
+
+st.plotly_chart(fig, use_container_width=True)
+
+# ---------- Data + Export ----------
+st.subheader("Latest rows")
+st.dataframe(df.tail(10)[["close", "SMA50", "SMA200", "EMA50", "EMA200", "RSI", "MACD", "MACDSignal"]])
+
+csv = df.to_csv().encode("utf-8")
+st.download_button(
+    "Download CSV", csv, file_name=f"btc_{timeframe}_signals.csv", mime="text/csv"
+)
+
+# ---------- Auto refresh ----------
+st.caption("Auto-refresh is enabled; page will update on interval.")
+time.sleep(refresh_s)
+st.experimental_rerun()

--- a/notebooks/BTC_Quant_Colab.ipynb
+++ b/notebooks/BTC_Quant_Colab.ipynb
@@ -194,6 +194,21 @@
     "* Click **Open live chart**; it will refresh until you interrupt that cell or click **Stop live**.\n",
     "* Click **Stop live** when you’re done."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Launch the Pro Dashboard (Streamlit)\n",
+    "Run locally:\n",
+    "1) `pip install -r requirements.txt`\n",
+    "2) `streamlit run dashboard/app.py`\n",
+    "\n",
+    "In Colab (basic):\n",
+    "- `!pip install -r requirements.txt`\n",
+    "- `!streamlit run dashboard/app.py --server.port 8501 --server.headless true`\n",
+    "(Expose via a tunnel if you want external URL.)\n"
+   ]
   }
  ],
  "metadata": {},

--- a/quant_core.py
+++ b/quant_core.py
@@ -1,0 +1,79 @@
+# Shared core logic used by both Streamlit and Colab
+import ccxt
+import pandas as pd
+from datetime import datetime
+import pytz
+
+TZ = pytz.timezone('America/Denver')
+
+
+def _exchange():
+    ex = ccxt.kraken({'enableRateLimit': True})
+    ex.load_markets()
+    market = 'BTC/USD' if 'BTC/USD' in ex.symbols else 'XBT/USD'
+    return ex, market
+
+
+def fetch_ohlcv(timeframe='1h', limit=500):
+    ex, market = _exchange()
+    ohlcv = ex.fetch_ohlcv(market, timeframe=timeframe, limit=limit)
+    df = pd.DataFrame(ohlcv, columns=['time', 'open', 'high', 'low', 'close', 'volume'])
+    df['time'] = pd.to_datetime(df['time'], unit='ms', utc=True).dt.tz_convert(TZ)
+    df.set_index('time', inplace=True)
+    return df
+
+
+def add_indicators(df):
+    df = df.copy()
+
+    # SMAs
+    df['SMA50'] = df['close'].rolling(50).mean()
+    df['SMA200'] = df['close'].rolling(200).mean()
+
+    # EMAs
+    df['EMA50'] = df['close'].ewm(span=50, adjust=False).mean()
+    df['EMA200'] = df['close'].ewm(span=200, adjust=False).mean()
+
+    # RSI (14)
+    delta = df['close'].diff()
+    gain = delta.clip(lower=0).rolling(14).mean()
+    loss = (-delta.clip(upper=0)).rolling(14).mean()
+    rs = gain / loss
+    df['RSI'] = 100 - (100 / (1 + rs))
+
+    # MACD (12,26,9)
+    ema12 = df['close'].ewm(span=12, adjust=False).mean()
+    ema26 = df['close'].ewm(span=26, adjust=False).mean()
+    df['MACD'] = ema12 - ema26
+    df['MACDSignal'] = df['MACD'].ewm(span=9, adjust=False).mean()
+    df['MACDHist'] = df['MACD'] - df['MACDSignal']
+
+    return df
+
+
+def classify_signal(row):
+    sma_bull = row['SMA50'] > row['SMA200']
+    sma_bear = row['SMA50'] < row['SMA200']
+    ema_bull = row['EMA50'] > row['EMA200']
+    ema_bear = row['EMA50'] < row['EMA200']
+    rsi_bull = row['RSI'] >= 50
+    rsi_bear = row['RSI'] <= 50
+    macd_bull = row['MACD'] > row['MACDSignal']
+    macd_bear = row['MACD'] < row['MACDSignal']
+
+    bull_votes = sum([sma_bull, ema_bull, rsi_bull, macd_bull])
+    bear_votes = sum([sma_bear, ema_bear, rsi_bear, macd_bear])
+
+    if bull_votes >= 3 and bull_votes > bear_votes:
+        return 'Bullish'
+    if bear_votes >= 3 and bear_votes > bull_votes:
+        return 'Bearish'
+    return 'Neutral'
+
+
+def latest_snapshot(timeframe='1h'):
+    df = add_indicators(fetch_ohlcv(timeframe))
+    last = df.iloc[-1]
+    sig = classify_signal(last)
+    now = datetime.now(TZ).strftime('%Y-%m-%d %H:%M:%S')
+    return df, sig, now

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+ccxt
+pandas
+pytz
+plotly
+streamlit


### PR DESCRIPTION
## Summary
- add quant_core module for shared data fetch, indicator calc, and signal classification
- create Streamlit dashboard with KPI cards, signal badge, Plotly charts, CSV export, and auto-refresh
- note in Colab notebook on installing dependencies and launching Streamlit

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile quant_core.py dashboard/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b00055f0dc832788fe4be43c846cd6