### PR TITLE
Add sync test print in quant_core

### DIFF
--- a/quant_core.py
+++ b/quant_core.py
@@ -77,3 +77,7 @@ def latest_snapshot(timeframe='1h'):
     sig = classify_signal(last)
     now = datetime.now(TZ).strftime('%Y-%m-%d %H:%M:%S')
     return df, sig, now
+
+
+if __name__ == "__main__":
+    print(">>> Codex Sync Test OK <<<")


### PR DESCRIPTION
## Summary
- print Codex Sync test confirmation when running quant_core as a script

## Testing
- `python quant_core.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b659f649308327a07be76a20b4d97d