### PR TITLE
Add config-driven CLI with settings file

### DIFF
--- a/conf/settings.yml
+++ b/conf/settings.yml
@@ -1,0 +1,18 @@
+exchange: binance
+symbol: BTC/USDT
+timeframe: 1h
+limit: 1000
+fees_bps: 2.5
+slippage_bps: 1.0
+risk:
+  mode: fixed_notional
+  notional_usd: 1000
+  max_leverage: 3
+stops:
+  type: atr
+  atr_mult: 2.0
+backtest:
+  days: 365
+  seed: 42
+logging:
+  dir: logs


### PR DESCRIPTION
## Summary
- load YAML settings from conf/settings.yml
- add CLI with live, backtest, report, and test modes
- save used config when report flag specified

## Testing
- `python quant_core.py --test`
- `python quant_core.py --backtest 5`


------
https://chatgpt.com/codex/tasks/task_e_68b66bad0ce48327a4ffa8b9090fb95e